### PR TITLE
Remove module map from outside of rsyncd

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -24,7 +24,7 @@ func TestErrors(t *testing.T) {
 	nonExistant := filepath.Join(tmp, "non/existant")
 
 	// start a server to sync from
-	srv := rsynctest.New(t, rsynctest.InteropModMap(nonExistant))
+	srv := rsynctest.New(t, rsynctest.InteropModule(nonExistant))
 
 	// sync into dest dir
 	var buf bytes.Buffer
@@ -106,7 +106,7 @@ func TestNoReadPermission(t *testing.T) {
 	}
 
 	// start a server to sync from
-	srv := rsynctest.New(t, rsynctest.InteropModMap(source))
+	srv := rsynctest.New(t, rsynctest.InteropModule(source))
 
 	// sync into dest dir
 	var buf bytes.Buffer

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,19 +21,14 @@ type Module struct {
 }
 
 type Config struct {
-	Listeners []Listener        `toml:"listener"`
-	Modules   []Module          `toml:"module"`
-	ModuleMap map[string]Module `toml:"-"`
+	Listeners []Listener `toml:"listener"`
+	Modules   []Module   `toml:"module"`
 }
 
 func FromString(input string) (*Config, error) {
 	var cfg Config
 	if _, err := toml.Decode(input, &cfg); err != nil {
 		return nil, err
-	}
-	cfg.ModuleMap = make(map[string]Module)
-	for _, m := range cfg.Modules {
-		cfg.ModuleMap[m.Name] = m
 	}
 	return &cfg, nil
 }

--- a/internal/maincmd/namespacing.go
+++ b/internal/maincmd/namespacing.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gokrazy/rsync/internal/config"
 )
 
-func namespace(modMap map[string]config.Module, listen string) error {
+func namespace(modules []config.Module, listen string) error {
 	if os.Getenv("GOKRAZY_RSYNC_PRIVDROP") != "" {
 		log.Printf("pid %d (privileges dropped)", os.Getpid())
 

--- a/internal/rsyncd/rsyncd.go
+++ b/internal/rsyncd/rsyncd.go
@@ -24,12 +24,21 @@ type sendTransfer struct {
 	lastMatch int64
 }
 
+func NewServer(modules ...config.Module) *Server {
+	moduleMap := map[string]config.Module{}
+	for _, module := range modules {
+		moduleMap[module.Name] = module
+	}
+
+	return &Server{moduleMap}
+}
+
 type Server struct {
-	Modules map[string]config.Module
+	modules map[string]config.Module
 }
 
 func (s *Server) getModule(requestedModule string) (config.Module, error) {
-	m, ok := s.Modules[requestedModule]
+	m, ok := s.modules[requestedModule]
 	if !ok {
 		return config.Module{}, fmt.Errorf("no such module")
 	}
@@ -37,11 +46,11 @@ func (s *Server) getModule(requestedModule string) (config.Module, error) {
 }
 
 func (s *Server) formatModuleList() string {
-	if len(s.Modules) == 0 {
+	if len(s.modules) == 0 {
 		return ""
 	}
 	var list strings.Builder
-	for name := range s.Modules {
+	for name := range s.modules {
 		comment := name // for now
 		fmt.Fprintf(&list, "%s\t%s\n",
 			name,

--- a/internal/rsyncd/rsyncd.go
+++ b/internal/rsyncd/rsyncd.go
@@ -25,24 +25,21 @@ type sendTransfer struct {
 }
 
 func NewServer(modules ...config.Module) *Server {
-	moduleMap := map[string]config.Module{}
-	for _, module := range modules {
-		moduleMap[module.Name] = module
-	}
-
-	return &Server{moduleMap}
+	return &Server{modules}
 }
 
 type Server struct {
-	modules map[string]config.Module
+	modules []config.Module
 }
 
 func (s *Server) getModule(requestedModule string) (config.Module, error) {
-	m, ok := s.modules[requestedModule]
-	if !ok {
-		return config.Module{}, fmt.Errorf("no such module")
+	for _, mod := range s.modules {
+		if mod.Name == requestedModule {
+			return mod, nil
+		}
 	}
-	return m, nil
+
+	return config.Module{}, fmt.Errorf("no such module: %s", requestedModule)
 }
 
 func (s *Server) formatModuleList() string {
@@ -50,10 +47,10 @@ func (s *Server) formatModuleList() string {
 		return ""
 	}
 	var list strings.Builder
-	for name := range s.modules {
-		comment := name // for now
+	for _, mod := range s.modules {
+		comment := mod.Name // for now
 		fmt.Fprintf(&list, "%s\t%s\n",
-			name,
+			mod.Name,
 			comment)
 	}
 	return list.String()

--- a/internal/rsynctest/rsynctest.go
+++ b/internal/rsynctest/rsynctest.go
@@ -34,11 +34,11 @@ type TestServer struct {
 	Port string
 }
 
-// InteropModMap is a convenience function to define an rsync module named
+// InteropModule is a convenience function to define an rsync module named
 // “interop” with the specified path.
-func InteropModMap(path string) map[string]config.Module {
-	return map[string]config.Module{
-		"interop": {
+func InteropModule(path string) []config.Module {
+	return []config.Module{
+		{
 			Name: "interop",
 			Path: path,
 		},
@@ -59,7 +59,7 @@ func Listener(ln net.Listener) Option {
 	}
 }
 
-func New(t *testing.T, modMap map[string]config.Module, opts ...Option) *TestServer {
+func New(t *testing.T, modules []config.Module, opts ...Option) *TestServer {
 	ts := &TestServer{}
 	for _, opt := range opts {
 		opt(ts)
@@ -69,9 +69,7 @@ func New(t *testing.T, modMap map[string]config.Module, opts ...Option) *TestSer
 			{Rsyncd: "localhost:0"},
 		}
 	}
-	srv := &rsyncd.Server{
-		Modules: modMap,
-	}
+	srv := rsyncd.NewServer(modules...)
 
 	if ts.listener == nil {
 		ln, err := net.Listen("tcp", "localhost:0")
@@ -91,7 +89,7 @@ func New(t *testing.T, modMap map[string]config.Module, opts ...Option) *TestSer
 
 	if ts.listeners[0].AnonSSH != "" {
 		cfg := &config.Config{
-			ModuleMap: modMap,
+			Modules: modules,
 		}
 		go func() {
 			err := anonssh.Serve(ts.listener, cfg, func(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {

--- a/interop_test.go
+++ b/interop_test.go
@@ -49,7 +49,7 @@ func TestModuleListing(t *testing.T) {
 	tmp := t.TempDir()
 
 	// start a server to sync from
-	srv := rsynctest.New(t, rsynctest.InteropModMap(tmp))
+	srv := rsynctest.New(t, rsynctest.InteropModule(tmp))
 
 	// request module list
 	var buf bytes.Buffer
@@ -96,7 +96,7 @@ func TestInterop(t *testing.T) {
 	}
 
 	// start a server to sync from
-	srv := rsynctest.New(t, rsynctest.InteropModMap(source))
+	srv := rsynctest.New(t, rsynctest.InteropModule(source))
 
 	// 	{
 	// 		config := filepath.Join(tmp, "rsyncd.conf")
@@ -288,7 +288,7 @@ func TestInteropSubdir(t *testing.T) {
 	_, source, dest := createSourceFiles(t)
 
 	// start a server to sync from
-	srv := rsynctest.New(t, rsynctest.InteropModMap(source))
+	srv := rsynctest.New(t, rsynctest.InteropModule(source))
 
 	// sync into dest dir
 	rsync := exec.Command("rsync", //"/home/michael/src/openrsync/openrsync",
@@ -414,7 +414,7 @@ func TestInteropRemoteDaemonAnonSSH(t *testing.T) {
 
 	// start a server to sync from
 	srv := rsynctest.New(t,
-		rsynctest.InteropModMap(source),
+		rsynctest.InteropModule(source),
 		rsynctest.Listeners([]config.Listener{
 			{AnonSSH: "localhost:0"},
 		}))

--- a/ipacl_test.go
+++ b/ipacl_test.go
@@ -93,7 +93,7 @@ acl = [
 					Port: 1234,
 				},
 			}
-			srv := rsynctest.New(t, cfg.ModuleMap, rsynctest.Listener(ln))
+			srv := rsynctest.New(t, cfg.Modules, rsynctest.Listener(ln))
 
 			// request module list: this should work regardless of the source IP
 			var buf bytes.Buffer

--- a/receiver_listing_test.go
+++ b/receiver_listing_test.go
@@ -42,7 +42,7 @@ func TestReceiverListing(t *testing.T) {
 	}
 
 	// start a server to sync from
-	srv := rsynctest.New(t, rsynctest.InteropModMap(source))
+	srv := rsynctest.New(t, rsynctest.InteropModule(source))
 
 	args := []string{
 		"gokr-rsync",

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -86,7 +86,7 @@ func TestReceiver(t *testing.T) {
 	}
 
 	// start a server to sync from
-	srv := rsynctest.New(t, rsynctest.InteropModMap(source))
+	srv := rsynctest.New(t, rsynctest.InteropModule(source))
 
 	args := []string{
 		"gokr-rsync",
@@ -198,7 +198,7 @@ func TestReceiverSync(t *testing.T) {
 	rsynctest.WriteLargeDataFile(t, source, headPattern, bodyPattern, endPattern)
 
 	// start a server to sync from
-	srv := rsynctest.New(t, rsynctest.InteropModMap(source))
+	srv := rsynctest.New(t, rsynctest.InteropModule(source))
 
 	args := []string{
 		"gokr-rsync",
@@ -246,7 +246,7 @@ func TestReceiverSSH(t *testing.T) {
 
 	// start a server to sync from
 	srv := rsynctest.New(t,
-		rsynctest.InteropModMap(source),
+		rsynctest.InteropModule(source),
 		rsynctest.Listeners([]config.Listener{
 			{AnonSSH: "localhost:0"},
 		}))

--- a/sync_test.go
+++ b/sync_test.go
@@ -24,7 +24,7 @@ func TestSyncExtended(t *testing.T) {
 	rsynctest.WriteLargeDataFile(t, source, headPattern, bodyPattern, endPattern)
 
 	// start a server to sync from
-	srv := rsynctest.New(t, rsynctest.InteropModMap(source))
+	srv := rsynctest.New(t, rsynctest.InteropModule(source))
 
 	sync := func() *rsyncparse.Stats {
 		rsync := exec.Command("rsync", //"/home/michael/src/openrsync/openrsync",


### PR DESCRIPTION
Bonus work found during https://github.com/gokrazy/rsync/issues/12

(Extracted from previous PR: https://github.com/gokrazy/rsync/pull/11)

(GitHub actions build pass in my fork)