### PR TITLE
Allow sender to append path to destination

### DIFF
--- a/integration/receiver/receiver_listing_test.go
+++ b/integration/receiver/receiver_listing_test.go
@@ -25,8 +25,18 @@ func TestReceiverListing(t *testing.T) {
 	if err := os.MkdirAll(source, 0755); err != nil {
 		t.Fatal(err)
 	}
+	// This explicit chmod might seem redundant at first,
+	// but is required to make the test pass with umask 027.
+	if err := os.Chmod(source, 0755); err != nil {
+		t.Fatal(err)
+	}
 	hello := filepath.Join(source, "hello")
 	if err := os.WriteFile(hello, []byte("world"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// This explicit chmod might seem redundant at first,
+	// but is required to make the test pass with umask 027.
+	if err := os.Chmod(hello, 0644); err != nil {
 		t.Fatal(err)
 	}
 	mtime, err := time.Parse(time.RFC3339, "2009-11-10T23:00:00Z")


### PR DESCRIPTION
Context:
https://github.com/gokrazy/rsync/issues/40

Assumptions:

- `handleConnReceiver` will have at most 1 path
- If no path is provided, destination will be `module.path` (default behavior)
- If path is provided, it is appended to `module.path` (new behavior)
- If no module is provided, behavior is unchanged

Tested:

`rsync -av {upload} rsync://{host}:{port}/{module}/{dest_path}`

{upload} will now be saved to {module.path}/{dest_path}