### PR TITLE
fix: Receivers should only chmod if permissions differ

### DIFF
--- a/internal/receiver/generator.go
+++ b/internal/receiver/generator.go
@@ -98,8 +98,10 @@ func (rt *Transfer) setPerms(f *File) error {
 
 	if mode != rsync.S_IFLNK {
 		// TODO(go1.25): use os.Root.Chmod
-		if err := os.Chmod(local, perm); err != nil {
-			return err
+		if st.Mode().Perm() != perm { // only call Chmod if the permissions actually differ
+			if err := os.Chmod(local, perm); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
I am building a higher level synchronization tool using the gokrazy/rsync library, and ran into a problem where changes are continuously picked up on different nodes _after_ a sync just ran because permission bits are always reset by the receiver. This small fix makes the problem go away.

Unfortunately, I can't think of a reasonable way to write a unit test for this, short of introducing some kind of DI mechanism for the Chmod call.