### PR TITLE
source directory has suffix will fail

### DIFF
--- a/internal/maincmd/clientmaincmd.go
+++ b/internal/maincmd/clientmaincmd.go
@@ -316,7 +316,7 @@ func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, 
 		for idx, path := range paths {
 			// Trailing slashes are meaningful to rsync,
 			// so preserve a trailing slash across filepath.Abs.
-			hasTrailingSlash := strings.HasSuffix(path, "/")
+			hasTrailingSlash := strings.HasSuffix(path, "/") || strings.HasSuffix(path, "\\")
 			abs, err := filepath.Abs(path)
 			if err != nil {
 				return nil, err

--- a/internal/sender/flist.go
+++ b/internal/sender/flist.go
@@ -59,12 +59,19 @@ var (
 
 func getRootStrip(requested, localDir string) (string, string) {
 	root := filepath.Clean(filepath.Join(localDir, requested))
-
 	sep := string(os.PathSeparator)
-	strip := filepath.Dir(filepath.Clean(root)) + sep
-	if strings.HasSuffix(requested, sep) {
+
+	isEndSep := strings.HasSuffix(requested, "\\") || strings.HasSuffix(requested, "/")
+	strip := ""
+	if !isEndSep {
+		strip = filepath.Dir(filepath.Clean(root)) + sep
+		if strings.HasSuffix(requested, sep) {
+			strip = filepath.Clean(root) + sep
+		}
+	} else {
 		strip = filepath.Clean(root) + sep
 	}
+
 	return root, strip
 }
 
@@ -359,12 +366,19 @@ func (st *Transfer) SendFileList(localDir string, paths []string, excl *filterRu
 		if st.Opts.Verbose() { // TODO: DebugGTE(FLIST, 1)
 			st.Logger.Printf("  path %q (local dir %q)", requested, localDir)
 		}
+
 		// st.Logger.Printf("getRootStrip(requested=%q, localDir=%q", requested, localDir)
 		rootPath, strip := getRootStrip(requested, localDir)
 		// st.Logger.Printf("root=%q, strip=%q", root, strip)
 		prefix := strings.TrimPrefix(rootPath, filepath.Clean(strip))
 		if prefix != "" {
 			prefix = strings.TrimPrefix(prefix, "/")
+
+			//add by yjh
+			//此处会导致服务器路径带\
+			prefix = strings.TrimPrefix(prefix, "\\")
+			//
+
 			prefix += "/"
 		}
 		if st.Opts.Verbose() { // TODO: DebugGTE(FLIST, 1)

--- a/internal/sender/flist.go
+++ b/internal/sender/flist.go
@@ -374,8 +374,7 @@ func (st *Transfer) SendFileList(localDir string, paths []string, excl *filterRu
 		if prefix != "" {
 			prefix = strings.TrimPrefix(prefix, "/")
 
-			//add by yjh
-			//此处会导致服务器路径带\
+			// server directory have prefix \
 			prefix = strings.TrimPrefix(prefix, "\\")
 			//
 


### PR DESCRIPTION
Command:  
C:\Users\yyy\Desktop\rsync\111\gokr-rsync.exe -av C:\Users\yyy\Desktop\rsync\111\gg ...server

Log:
2025/12/26 15:17:20 rsyncos.go:32: remote protocol: 31
2025/12/26 15:17:20 rsyncos.go:32: sender(paths=["C:\\Users\\yyy\\Desktop\\rsync\\111\\gg"])
2025/12/26 15:17:20 do.go:43: SendFileList(modPath="\\\\?\\", paths=["C:\\Users\\yyy\\Desktop\\rsync\\111\\gg"])
2025/12/26 15:17:20 flist.go:345: sendFileList()
2025/12/26 15:17:20 flist.go:360:   path "C:\\Users\\yyy\\Desktop\\rsync\\111\\gg" (local dir "\\\\?\\")
2025/12/26 15:17:20 flist.go:371:   filepath.Walk("\\\\?\\C:\\Users\\yyy\\Desktop\\rsync\\111\\gg"), strip="\\\\?\\C:\\Users\\yyy\\Desktop\\rsync\\111\\"
2025/12/26 15:17:20 flist.go:372:   prefix="\\gg/"
2025/12/26 15:17:20 flist.go:141: filepath.WalkFn(path=.)
2025/12/26 15:17:20 flist.go:152: isDir=true, xferDirs=1
2025/12/26 15:17:20 flist.go:162: Trim(path=".") = "\\gg/."
2025/12/26 15:17:20 flist.go:141: filepath.WalkFn(path=11.txt)
2025/12/26 15:17:20 flist.go:152: isDir=false, xferDirs=1
2025/12/26 15:17:20 flist.go:162: Trim(path="11.txt") = "\\gg/11.txt"
2025/12/26 15:17:20 do.go:51: file list sent
2025/12/26 15:17:20 rsyncos.go:32: info: \gg/

Server:
<img width="436" height="161" alt="image" src="https://github.com/user-attachments/assets/a9a9c853-3480-4b3f-8beb-29c89a941179" />