### PR TITLE
rsyncd: implement daemon protocol authentication

### DIFF
--- a/fileinfo.go
+++ b/fileinfo.go
@@ -1,0 +1,11 @@
+package rsync
+
+import "time"
+
+type FileInfo struct {
+	Name     string
+	Length   int64
+	ModTime  time.Time
+	Mode     int32
+	Checksum [16]byte
+}

--- a/internal/maincmd/clientmaincmd.go
+++ b/internal/maincmd/clientmaincmd.go
@@ -422,6 +422,7 @@ func clientMain(ctx context.Context, osenv *rsyncos.Env, opts *rsyncopts.Options
 	if len(remaining) == 1 {
 		// Usages with just one SRC arg and no DEST arg list the source files
 		// instead of copying.
+		opts.SetListOnly()
 		dest := ""
 		sources := remaining
 		return rsyncMain(ctx, osenv, opts, sources, dest)

--- a/internal/maincmd/clientmaincmd.go
+++ b/internal/maincmd/clientmaincmd.go
@@ -146,7 +146,7 @@ func rsyncMain(ctx context.Context, osenv *rsyncos.Env, opts *rsyncopts.Options,
 		}
 		negotiate = false // already done
 	}
-	stats, err := ClientRun(osenv, opts, conn, paths, negotiate)
+	stats, _, err := ClientRun(osenv, opts, conn, paths, negotiate)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func doCmd(osenv *rsyncos.Env, opts *rsyncopts.Options, machine, user, path stri
 }
 
 // rsync/main.c:client_run
-func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, paths []string, negotiate bool) (*rsyncstats.TransferStats, error) {
+func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, paths []string, negotiate bool) (*rsyncstats.TransferStats, []rsync.FileInfo, error) {
 	crd := &rsyncwire.CountingReader{R: conn}
 	cwr := &rsyncwire.CountingWriter{W: conn}
 	c := &rsyncwire.Conn{
@@ -264,11 +264,11 @@ func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, 
 
 	if negotiate {
 		if err := c.WriteInt32(rsync.ProtocolVersion); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		remoteProtocol, err := c.ReadInt32()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if opts.Verbose() {
 			osenv.Logf("remote protocol: %d", remoteProtocol)
@@ -277,7 +277,7 @@ func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, 
 
 	seed, err := c.ReadInt32()
 	if err != nil {
-		return nil, fmt.Errorf("reading seed: %v", err)
+		return nil, nil, fmt.Errorf("reading seed: %v", err)
 	}
 
 	mrd := &rsyncwire.MultiplexReader{
@@ -317,7 +317,7 @@ func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, 
 			hasTrailingSlash := strings.HasSuffix(path, "/")
 			abs, err := filepath.Abs(path)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			paths[idx] = abs
 			if hasTrailingSlash {
@@ -327,13 +327,13 @@ func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, 
 
 		stats, err := st.Do(crd, cwr, FileSystemRoot, paths, nil)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return stats, nil
+		return stats, nil, nil
 	}
 
 	if len(paths) != 1 {
-		return nil, fmt.Errorf("BUG: expected exactly one path, got %q", paths)
+		return nil, nil, fmt.Errorf("BUG: expected exactly one path, got %q", paths)
 	}
 
 	rt := &receiver.Transfer{
@@ -371,16 +371,16 @@ func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, 
 		// just listing modules, not transferring anything
 	} else {
 		if err := os.MkdirAll(rt.Dest, 0755); err != nil {
-			return nil, fmt.Errorf("MkdirAll(dest=%s): %v", rt.Dest, err)
+			return nil, nil, fmt.Errorf("MkdirAll(dest=%s): %v", rt.Dest, err)
 		}
 		rt.DestRoot, err = os.OpenRoot(rt.Dest)
 		if err != nil {
-			return nil, fmt.Errorf("OpenRoot(dest=%s): %v", rt.Dest, err)
+			return nil, nil, fmt.Errorf("OpenRoot(dest=%s): %v", rt.Dest, err)
 		}
 		defer rt.DestRoot.Close()
 		if osenv.Restrict() {
 			if err := restrict.MaybeFileSystem(nil, []string{rt.Dest}); err != nil {
-				return nil, fmt.Errorf("landlock: %v", err)
+				return nil, nil, fmt.Errorf("landlock: %v", err)
 			}
 		}
 	}
@@ -391,7 +391,7 @@ func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, 
 	}
 	const exclusionListEnd = 0
 	if err := c.WriteInt32(exclusionListEnd); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if opts.DebugGTE(rsyncopts.DEBUG_RECV, 1) {
@@ -404,13 +404,28 @@ func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, 
 	}
 	fileList, err := rt.ReceiveFileList()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if opts.DebugGTE(rsyncopts.DEBUG_FLIST, 2) {
 		osenv.Logf("received %d names", len(fileList))
 	}
 
-	return rt.Do(c, fileList, false)
+	fileInfos := make([]rsync.FileInfo, len(fileList))
+	for i, f := range fileList {
+		fileInfos[i] = rsync.FileInfo{
+			Name:     f.Name,
+			Length:   f.Length,
+			ModTime:  f.ModTime,
+			Mode:     f.Mode,
+			Checksum: f.Checksum,
+		}
+	}
+
+	stats, err := rt.Do(c, fileList, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	return stats, fileInfos, nil
 }
 
 func clientMain(ctx context.Context, osenv *rsyncos.Env, opts *rsyncopts.Options, remaining []string) (*rsyncstats.TransferStats, error) {

--- a/internal/maincmd/clientserver.go
+++ b/internal/maincmd/clientserver.go
@@ -78,7 +78,7 @@ func socketClient(ctx context.Context, osenv *rsyncos.Env, opts *rsyncopts.Optio
 	if done {
 		return nil, nil
 	}
-	stats, err := ClientRun(osenv, opts, conn, paths, false)
+	stats, _, err := ClientRun(osenv, opts, conn, paths, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/maincmd/clientserver.go
+++ b/internal/maincmd/clientserver.go
@@ -3,9 +3,13 @@ package maincmd
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
+	"net/url"
+	"os"
+	"os/user"
 	"strconv"
 	"strings"
 	"time"
@@ -15,10 +19,25 @@ import (
 	"github.com/gokrazy/rsync/internal/rsyncopts"
 	"github.com/gokrazy/rsync/internal/rsyncos"
 	"github.com/gokrazy/rsync/internal/rsyncstats"
+	"github.com/mmcloughlin/md4"
 )
 
 // rsync/clientserver.c:start_socket_client
 func socketClient(ctx context.Context, osenv *rsyncos.Env, opts *rsyncopts.Options, host string, remotePath string, port int, paths []string, roDirs, rwDirs []string) (*rsyncstats.TransferStats, error) {
+	// Extract user[:password]@ from host (daemon protocol only).
+	// Password may be percent-encoded from net/url parsing.
+	var urlUser, urlPass string
+	if idx := strings.IndexByte(host, '@'); idx > -1 {
+		userinfo := host[:idx]
+		host = host[idx+1:]
+		if ci := strings.IndexByte(userinfo, ':'); ci > -1 {
+			urlUser = userinfo[:ci]
+			urlPass, _ = url.PathUnescape(userinfo[ci+1:])
+		} else {
+			urlUser = userinfo
+		}
+	}
+
 	if port < 0 {
 		if port := opts.RsyncPort(); port > 0 {
 			host += ":" + strconv.Itoa(port)
@@ -52,7 +71,7 @@ func socketClient(ctx context.Context, osenv *rsyncos.Env, opts *rsyncopts.Optio
 			return nil, err
 		}
 	}
-	done, err := StartInbandExchange(osenv, opts, conn, remotePath)
+	done, err := startInbandExchange(osenv, opts, conn, remotePath, urlUser, urlPass)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +85,14 @@ func socketClient(ctx context.Context, osenv *rsyncos.Env, opts *rsyncopts.Optio
 	return stats, nil
 }
 
-// rsync/clientserver.c:start_inband_exchange
+// StartInbandExchange is the public API for daemon-over-remote-shell
+// and the rsyncclient package. Auth credentials come from env/file only.
 func StartInbandExchange(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, remotePath string) (done bool, _ error) {
+	return startInbandExchange(osenv, opts, conn, remotePath, "", "")
+}
+
+// rsync/clientserver.c:start_inband_exchange
+func startInbandExchange(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, remotePath string, urlUser, urlPass string) (done bool, _ error) {
 	module := remotePath
 	if idx := strings.IndexByte(module, '/'); idx > -1 {
 		module = module[:idx]
@@ -119,8 +144,15 @@ func StartInbandExchange(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.Re
 		}
 
 		if strings.HasPrefix(line, "@RSYNCD: AUTHREQD ") {
-			// TODO: implement support for authentication
-			return false, fmt.Errorf("authentication not yet implemented")
+			challenge := strings.TrimPrefix(line, "@RSYNCD: AUTHREQD ")
+			authUser := resolveUsername(urlUser)
+			pass, err := getPassword(opts, urlPass)
+			if err != nil {
+				return false, fmt.Errorf("authentication required: %v", err)
+			}
+			hash := generateAuthHash(pass, challenge)
+			fmt.Fprintf(conn, "%s %s\n", authUser, hash)
+			continue
 		}
 
 		if line == "@RSYNCD: OK" {
@@ -154,4 +186,52 @@ func StartInbandExchange(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.Re
 	fmt.Fprintf(conn, "\n")
 
 	return false, nil
+}
+
+// resolveUsername returns the auth username from (in priority order):
+// URL user, RSYNC_USERNAME env, current OS user, or "nobody".
+func resolveUsername(urlUser string) string {
+	if urlUser != "" {
+		return urlUser
+	}
+	if u := os.Getenv("RSYNC_USERNAME"); u != "" {
+		return u
+	}
+	if u, err := user.Current(); err == nil && u.Username != "" {
+		return u.Username
+	}
+	return "nobody"
+}
+
+// getPassword returns the auth password from (in priority order):
+// URL password, --password-file, or RSYNC_PASSWORD env.
+func getPassword(opts *rsyncopts.Options, urlPass string) (string, error) {
+	if urlPass != "" {
+		return urlPass, nil
+	}
+	if f := opts.PasswordFile(); f != "" {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return "", fmt.Errorf("reading password file: %v", err)
+		}
+		lines := strings.SplitN(string(data), "\n", 2)
+		return strings.TrimRight(lines[0], "\r"), nil
+	}
+	if p := os.Getenv("RSYNC_PASSWORD"); p != "" {
+		return p, nil
+	}
+	return "", fmt.Errorf("no password supplied (set RSYNC_PASSWORD or use --password-file)")
+}
+
+// generateAuthHash computes the rsync CSUM_MD4_OLD auth response:
+// MD4(seed + password + challenge), base64-encoded without padding.
+// CSUM_MD4_OLD prepends a 4-byte little-endian seed (0 for auth)
+// before the password and challenge data.
+func generateAuthHash(password, challenge string) string {
+	h := md4.New()
+	h.Write([]byte{0, 0, 0, 0})
+	h.Write([]byte(password))
+	h.Write([]byte(challenge))
+	digest := h.Sum(nil)
+	return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString(digest)
 }

--- a/internal/maincmd/options.go
+++ b/internal/maincmd/options.go
@@ -2,6 +2,7 @@ package maincmd
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -104,10 +105,18 @@ func parseHostspec(src string, parsingURL bool) (host, path string, port int, _ 
 // rsync/options.c:check_for_hostspec
 func checkForHostspec(src string) (host, path string, port int, _ error) {
 	if strings.HasPrefix(src, "rsync://") {
-		var err error
-		if host, path, port, err = parseHostspec(strings.TrimPrefix(src, "rsync://"), true); err == nil {
-			if port == 0 {
-				port = -1
+		u, err := url.Parse(src)
+		if err == nil && u.Hostname() != "" {
+			host = u.Hostname()
+			if u.User != nil {
+				host = u.User.String() + "@" + host
+			}
+			path = strings.TrimPrefix(u.Path, "/")
+			port = -1
+			if u.Port() != "" {
+				if p, err := strconv.Atoi(u.Port()); err == nil {
+					port = p
+				}
 			}
 			return host, path, port, nil
 		}

--- a/internal/rsyncopts/rsyncopts.go
+++ b/internal/rsyncopts/rsyncopts.go
@@ -728,6 +728,7 @@ func (o *Options) AlwaysChecksum() bool       { return o.always_checksum != 0 }
 func (o *Options) IgnoreTimes() bool          { return o.ignore_times != 0 }
 func (o *Options) OutputMOTD() bool           { return o.output_motd != 0 }
 func (o *Options) RsyncPort() int             { return o.rsync_port }
+func (o *Options) PasswordFile() string       { return o.password_file }
 func (o *Options) XferDirs() int              { return o.xfer_dirs }
 func (o *Options) FilterRules() []string      { return o.filterRules }
 func (o *Options) Progress() bool {
@@ -1021,7 +1022,7 @@ func (o *Options) gokrazyTable() []poptOption {
 		//{"address", "", POPT_ARG_STRING, &o.bind_address, 0},
 		{"port", "", POPT_ARG_INT, &o.rsync_port, 0},
 		//{"sockopts", "", POPT_ARG_STRING, &o.sockopts, 0},
-		//{"password-file", "", POPT_ARG_STRING, &o.password_file, 0},
+		{"password-file", "", POPT_ARG_STRING, &o.password_file, 0},
 		//{"early-input", "", POPT_ARG_STRING, &o.early_input_file, 0},
 		//{"blocking-io", "", POPT_ARG_VAL, &o.blocking_io, 1},
 		//{"no-blocking-io", "", POPT_ARG_VAL, &o.blocking_io, 0},

--- a/internal/rsyncopts/rsyncopts.go
+++ b/internal/rsyncopts/rsyncopts.go
@@ -719,6 +719,12 @@ func (o *Options) Verbose() bool              { return o.verbose != 0 }
 func (o *Options) DeleteMode() bool           { return o.delete_mode != 0 }
 func (o *Options) Sender() bool               { return o.am_sender != 0 }
 func (o *Options) SetSender()                 { o.am_sender = 1 }
+func (o *Options) SetListOnly() {
+	o.list_only = 1
+	if o.recurse == 0 {
+		o.xfer_dirs = 1
+	}
+}
 func (o *Options) LocalServer() bool          { return o.local_server != 0 }
 func (o *Options) SetLocalServer()            { o.local_server = 1 }
 func (o *Options) Server() bool               { return o.am_server != 0 }

--- a/internal/rsyncopts/serveroptions.go
+++ b/internal/rsyncopts/serveroptions.go
@@ -89,12 +89,9 @@ func (o *Options) ServerOptions() []string {
 	// if (do_compression)
 	// 	argstr[x++] = 'z';
 
-	// /* this is a complete hack - blame Rusty
-
-	//    this is a hack to make the list_only (remote file list)
-	//    more useful */
-	// if (list_only && !recurse)
-	// 	argstr[x++] = 'r';
+	if o.xfer_dirs > 0 && !o.Recurse() {
+		argstr += "d"
+	}
 
 	// argstr[x] = 0;
 

--- a/rsyncclient/rsyncclient.go
+++ b/rsyncclient/rsyncclient.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/gokrazy/rsync"
 	"github.com/gokrazy/rsync/internal/maincmd"
 	"github.com/gokrazy/rsync/internal/rsyncopts"
 	"github.com/gokrazy/rsync/internal/rsyncos"
@@ -100,7 +101,8 @@ func (c *Client) ServerCommandOptions(path string, paths ...string) []string {
 
 // Result contains information about a transfer.
 type Result struct {
-	Stats *rsyncstats.TransferStats
+	Stats    *rsyncstats.TransferStats
+	FileList []rsync.FileInfo
 }
 
 // Run starts one run of the rsync protocol (not the rsync daemon protocol), see
@@ -121,11 +123,11 @@ type Result struct {
 // [Client.ServerCommandOptions] to the server and then arrange for two
 // [io.ReadWriter] connections between client and server.
 func (c *Client) Run(ctx context.Context, conn io.ReadWriter, paths []string) (*Result, error) {
-	stats, err := maincmd.ClientRun(c.osenv, c.opts, conn, paths, c.negotiate)
+	stats, fileList, err := maincmd.ClientRun(c.osenv, c.opts, conn, paths, c.negotiate)
 	if err != nil {
 		return nil, err
 	}
-	return &Result{Stats: stats}, nil
+	return &Result{Stats: stats, FileList: fileList}, nil
 }
 
 // RunDaemon starts one run of the rsync daemon protocol, meaning it performs

--- a/rsyncd/rsyncd.go
+++ b/rsyncd/rsyncd.go
@@ -7,6 +7,8 @@ package rsyncd
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -25,14 +27,17 @@ import (
 	"github.com/gokrazy/rsync/internal/rsyncos"
 	"github.com/gokrazy/rsync/internal/rsyncwire"
 	"github.com/gokrazy/rsync/internal/sender"
+	"github.com/mmcloughlin/md4"
 )
 
 type Module struct {
-	Name     string   `toml:"name"`
-	Path     string   `toml:"path"` // If empty, FS must be non-nil
-	FS       fs.FS    `toml:"-"`    // If set, serve from this instead of Path
-	ACL      []string `toml:"acl"`
-	Writable bool     `toml:"writable"` // Must be false if FS is set
+	Name        string   `toml:"name"`
+	Path        string   `toml:"path"` // If empty, FS must be non-nil
+	FS          fs.FS    `toml:"-"`    // If set, serve from this instead of Path
+	ACL         []string `toml:"acl"`
+	Writable    bool     `toml:"writable"`     // Must be false if FS is set
+	AuthUsers   []string `toml:"auth_users"`   // Usernames allowed to connect; empty means no auth
+	SecretsFile string   `toml:"secrets_file"` // Path to file with user:password lines
 }
 
 // Option specifies the server options.
@@ -227,6 +232,13 @@ func (s *Server) HandleDaemonConn(ctx context.Context, conn *Conn) (err error) {
 	if err := checkACL(module.ACL, conn.name); err != nil {
 		fmt.Fprintf(cwr, "@ERROR: %v\n", err)
 		return err
+	}
+
+	if len(module.AuthUsers) > 0 {
+		if err := s.authServer(rd, cwr, &module, conn.name); err != nil {
+			fmt.Fprintf(cwr, "@ERROR: auth failed on module %s\n", module.Name)
+			return err
+		}
 	}
 
 	io.WriteString(cwr, terminationCommand)
@@ -601,6 +613,91 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 			}
 		}()
 	}
+}
+
+func (s *Server) authServer(rd *bufio.Reader, cwr io.Writer, module *Module, remoteAddr string) error {
+	challenge := genChallenge()
+	fmt.Fprintf(cwr, "@RSYNCD: AUTHREQD %s\n", challenge)
+
+	line, err := rd.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("reading auth response: %v", err)
+	}
+	line = strings.TrimSpace(line)
+	sp := strings.IndexByte(line, ' ')
+	if sp < 0 {
+		s.logger.Printf("auth failed on module %s from %s: invalid response", module.Name, remoteAddr)
+		return fmt.Errorf("invalid auth response")
+	}
+	user, response := line[:sp], line[sp+1:]
+
+	matched := false
+	for _, allowed := range module.AuthUsers {
+		if allowed == user {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		s.logger.Printf("auth failed on module %s from %s for %s: unknown user", module.Name, remoteAddr, user)
+		return fmt.Errorf("auth failed")
+	}
+
+	secret, err := lookupSecret(module.SecretsFile, user)
+	if err != nil {
+		s.logger.Printf("auth failed on module %s from %s for %s: %v", module.Name, remoteAddr, user, err)
+		return fmt.Errorf("auth failed")
+	}
+
+	expected := authHash(secret, challenge)
+	if response != expected {
+		s.logger.Printf("auth failed on module %s from %s for %s: password mismatch", module.Name, remoteAddr, user)
+		return fmt.Errorf("auth failed")
+	}
+
+	s.logger.Printf("auth ok on module %s from %s for %s", module.Name, remoteAddr, user)
+	return nil
+}
+
+func genChallenge() string {
+	var buf [16]byte
+	rand.Read(buf[:])
+	h := md4.New()
+	h.Write([]byte{0, 0, 0, 0})
+	h.Write(buf[:])
+	return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString(h.Sum(nil))
+}
+
+func authHash(password, challenge string) string {
+	h := md4.New()
+	h.Write([]byte{0, 0, 0, 0})
+	h.Write([]byte(password))
+	h.Write([]byte(challenge))
+	return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString(h.Sum(nil))
+}
+
+func lookupSecret(path, user string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("no secrets file configured")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading secrets file: %v", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line[0] == '#' {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[0] == user {
+			return parts[1], nil
+		}
+	}
+	return "", fmt.Errorf("user not found in secrets file")
 }
 
 func validateModule(mod Module) error {


### PR DESCRIPTION
## Summary
- Implement client-side rsync daemon (rsync://) password authentication via MD4 challenge-response
- Implement server-side daemon authentication with secrets file support
- Support password from URL (`rsync://user:pass@host/module`), `--password-file`, `RSYNC_PASSWORD` env var
- Add `AuthUsers` and `SecretsFile` fields to `rsyncd.Module` for server-side auth config

## Test plan
- [x] Tested gorsync client against stock rsync 3.4.1 daemon with auth
- [x] Tested stock rsync client against gorsync server with auth
- [x] Tested gorsync client against gorsync server with auth
- [x] Verified wrong password and wrong user are rejected
- [x] Verified `RSYNC_PASSWORD`, `--password-file`, and URL password all work
- [x] All existing tests pass