### PR TITLE
rsyncopts: implement list-only mode for daemon connections

### DIFF
--- a/internal/maincmd/clientmaincmd.go
+++ b/internal/maincmd/clientmaincmd.go
@@ -422,6 +422,7 @@ func clientMain(ctx context.Context, osenv *rsyncos.Env, opts *rsyncopts.Options
 	if len(remaining) == 1 {
 		// Usages with just one SRC arg and no DEST arg list the source files
 		// instead of copying.
+		opts.SetListOnly()
 		dest := ""
 		sources := remaining
 		return rsyncMain(ctx, osenv, opts, sources, dest)

--- a/internal/rsyncopts/rsyncopts.go
+++ b/internal/rsyncopts/rsyncopts.go
@@ -719,6 +719,12 @@ func (o *Options) Verbose() bool              { return o.verbose != 0 }
 func (o *Options) DeleteMode() bool           { return o.delete_mode != 0 }
 func (o *Options) Sender() bool               { return o.am_sender != 0 }
 func (o *Options) SetSender()                 { o.am_sender = 1 }
+func (o *Options) SetListOnly() {
+	o.list_only = 1
+	if o.recurse == 0 {
+		o.xfer_dirs = 1
+	}
+}
 func (o *Options) LocalServer() bool          { return o.local_server != 0 }
 func (o *Options) SetLocalServer()            { o.local_server = 1 }
 func (o *Options) Server() bool               { return o.am_server != 0 }

--- a/internal/rsyncopts/serveroptions.go
+++ b/internal/rsyncopts/serveroptions.go
@@ -89,12 +89,9 @@ func (o *Options) ServerOptions() []string {
 	// if (do_compression)
 	// 	argstr[x++] = 'z';
 
-	// /* this is a complete hack - blame Rusty
-
-	//    this is a hack to make the list_only (remote file list)
-	//    more useful */
-	// if (list_only && !recurse)
-	// 	argstr[x++] = 'r';
+	if o.xfer_dirs > 0 && !o.Recurse() {
+		argstr += "d"
+	}
 
 	// argstr[x] = 0;
 


### PR DESCRIPTION
## Summary
- Set list_only and xfer_dirs when invoked with a single source and no dest
- Send -d flag in server options when xfer_dirs is set without recursion
- Enables `gokr-rsync rsync://host/module/` to list directory contents like stock rsync

## Test plan
- [x] Tested against remote rsync 3.4.1 daemon — produces matching output
- [x] All existing tests pass