### PR TITLE
rsyncwire: don't treat MSG_ERROR_XFER as fatal

### DIFF
--- a/internal/rsyncwire/wire.go
+++ b/internal/rsyncwire/wire.go
@@ -5,14 +5,23 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/gokrazy/rsync/internal/rsyncos"
 )
 
+// Multiplex message tags, mirroring rsync.h's MSG_* constants. MSG_ERROR_XFER
+// (1) and MSG_ERROR (3) are non-fatal logging messages from the peer in real
+// rsync — losing one file's stat is not a reason to abort the whole transfer.
+// MSG_ERROR_SOCKET (5) is a peer-side socket-level error and is fatal.
 const (
-	MsgData  uint8 = 0
-	MsgInfo  uint8 = 2
-	MsgError uint8 = 1
+	MsgData         uint8 = 0
+	MsgErrorXfer    uint8 = 1
+	MsgInfo         uint8 = 2
+	MsgError        uint8 = 3
+	MsgWarning      uint8 = 4
+	MsgErrorSocket  uint8 = 5
+	MsgLog          uint8 = 6
 )
 
 const mplexBase = 7
@@ -75,12 +84,15 @@ func (w *MultiplexReader) Read(p []byte) (n int, err error) {
 		return 0, err
 	}
 	switch tag {
-	case MsgError:
-		return 0, fmt.Errorf("%s", payload)
-	case MsgInfo:
-		w.Env.Logf("info: %s", payload)
+	case MsgErrorXfer, MsgError, MsgWarning, MsgLog:
+		w.Env.Logf("rsync: %s", strings.TrimRight(string(payload), "\n"))
 		// io.ReadFull will call Read again
 		return 0, nil
+	case MsgInfo:
+		w.Env.Logf("info: %s", payload)
+		return 0, nil
+	case MsgErrorSocket:
+		return 0, fmt.Errorf("rsync socket error: %s", strings.TrimRight(string(payload), "\n"))
 	case MsgData:
 		// continues below
 	default:

--- a/rsyncd/rsyncd.go
+++ b/rsyncd/rsyncd.go
@@ -266,7 +266,7 @@ func (s *Server) HandleDaemonConn(ctx context.Context, conn *Conn) (err error) {
 		// Switch to multiplexing protocol, but only for server-side transmissions.
 		// Transmissions received from the client are not multiplexed.
 		mpx := &rsyncwire.MultiplexWriter{Writer: c.Writer}
-		mpx.WriteMsg(rsyncwire.MsgError, fmt.Appendf(nil, "gokr-rsync [sender]: %v\n", err))
+		mpx.WriteMsg(rsyncwire.MsgErrorXfer, fmt.Appendf(nil, "gokr-rsync [sender]: %v\n", err))
 
 		return err
 	}
@@ -386,7 +386,7 @@ func (s *Server) handleConn(ctx context.Context, conn *Conn, module *Module, pc 
 		// If returning an error, send the error to the client for display, too:
 		defer func() {
 			if err != nil {
-				mpx.WriteMsg(rsyncwire.MsgError, fmt.Appendf(nil, "gokr-rsync [sender]: %v\n", err))
+				mpx.WriteMsg(rsyncwire.MsgErrorXfer, fmt.Appendf(nil, "gokr-rsync [sender]: %v\n", err))
 			}
 		}()
 
@@ -396,7 +396,7 @@ func (s *Server) handleConn(ctx context.Context, conn *Conn, module *Module, pc 
 	// If returning an error, send the error to the client for display, too:
 	defer func() {
 		if err != nil {
-			mpx.WriteMsg(rsyncwire.MsgError, fmt.Appendf(nil, "gokr-rsync [receiver]: %v\n", err))
+			mpx.WriteMsg(rsyncwire.MsgErrorXfer, fmt.Appendf(nil, "gokr-rsync [receiver]: %v\n", err))
 		}
 	}()
 	return s.handleConnReceiver(module, crd, cwr, paths, opts, false, c, sessionChecksumSeed)


### PR DESCRIPTION
## Summary

Fix a bug where any per-transfer error from the peer aborts the entire rsync session instead of being logged and skipped.

The old code defines a single `MsgError` constant at tag `1` and treats it as fatal in `MultiplexReader.Read`:

```go
case MsgError:
    return 0, fmt.Errorf("%s", payload)
```

Per the rsync wire protocol (`rsync.h`), tag `1` is `MSG_ERROR_XFER`, which real rsync logs to stderr and continues past — typical examples are server-side `readlink_stat` failures on individual files. Only tag `5` (`MSG_ERROR_SOCKET`) is genuinely fatal at the socket layer; tags `3` / `4` / `6` (`MSG_ERROR` / `MSG_WARNING` / `MSG_LOG`) are also logged-and-continued in real rsync.

## Symptom

`rsync -r --list-only rsync://some-mirror/path/` against any reasonably populated mirror aborts with the first per-file stat error after a few seconds, even though the same listing succeeds with real rsync (which prints a few thousand warnings then finishes the listing).

Reproducer using `rsynccmd`:

```go
cmd := rsynccmd.Command("rsync", "-r", "rsync://some-mirror/path/")
cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
_, err := cmd.Run(ctx)
// err: "rsync: readlink_stat(\"...\") failed: Input/output error (5)"
// stdout has 0 lines.
```

Real rsync against the same URL produces hundreds of thousands of stdout lines plus a few thousand stderr warnings.

## Changes

- Rename the existing tag-1 constant from `MsgError` to `MsgErrorXfer` to match its protocol semantics.
- Add `MsgError` (3), `MsgWarning` (4), `MsgErrorSocket` (5), `MsgLog` (6).
- In `MultiplexReader.Read`, log `MsgErrorXfer` / `MsgError` / `MsgWarning` / `MsgLog` payloads via `Env.Logf` and continue reading. Treat `MsgErrorSocket` as fatal. Other unknown tags remain "unexpected tag".
- `rsyncd.go`'s three sender / receiver-side error sends are renamed to `MsgErrorXfer`; they were already semantically per-session errors.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean (the two warnings shown are pre-existing on upstream/main)
- [x] Existing tests pass (`go test ./internal/rsyncwire/... ./rsyncd/...`)
- [ ] Manual: `rsynccmd.Command("rsync", "-r", URL)` against a public mirror with unreadable files now completes and emits the file list, with warnings logged via `Env.Stderr`
