### PR TITLE
rsyncopts: accept and honor --whole-file/-W

### DIFF
--- a/internal/maincmd/clientmaincmd.go
+++ b/internal/maincmd/clientmaincmd.go
@@ -354,6 +354,7 @@ func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, 
 			PreserveHardlinks: opts.PreserveHardLinks(),
 			IgnoreTimes:       opts.IgnoreTimes(),
 			AlwaysChecksum:    opts.AlwaysChecksum(),
+			WholeFile:         opts.WholeFile(),
 
 			InfoGTE:  opts.InfoGTE,
 			DebugGTE: opts.DebugGTE,

--- a/internal/receiver/generator.go
+++ b/internal/receiver/generator.go
@@ -302,7 +302,9 @@ func (rt *Transfer) recvGenerator(idx int, f *File) error {
 		return nil
 	}
 
-	// TODO: if deltas are disabled, request the file in full
+	if rt.Opts.WholeFile {
+		return requestFullFile()
+	}
 
 	in, err := rt.DestRoot.Open(f.Name)
 	if err != nil {

--- a/internal/receiver/transfer.go
+++ b/internal/receiver/transfer.go
@@ -28,6 +28,7 @@ type TransferOpts struct {
 	PreserveHardlinks bool
 	IgnoreTimes       bool
 	AlwaysChecksum    bool
+	WholeFile         bool
 
 	InfoGTE  func(rsyncopts.InfoLevel, uint16) bool
 	DebugGTE func(rsyncopts.DebugLevel, uint16) bool

--- a/internal/rsyncopts/rsyncopts.go
+++ b/internal/rsyncopts/rsyncopts.go
@@ -725,6 +725,7 @@ func (o *Options) Server() bool               { return o.am_server != 0 }
 func (o *Options) Daemon() bool               { return o.am_daemon != 0 }
 func (o *Options) ConnectTimeoutSeconds() int { return o.connect_timeout }
 func (o *Options) AlwaysChecksum() bool       { return o.always_checksum != 0 }
+func (o *Options) WholeFile() bool             { return o.whole_file > 0 }
 func (o *Options) IgnoreTimes() bool          { return o.ignore_times != 0 }
 func (o *Options) OutputMOTD() bool           { return o.output_motd != 0 }
 func (o *Options) RsyncPort() int             { return o.rsync_port }
@@ -922,9 +923,9 @@ func (o *Options) gokrazyTable() []poptOption {
 		//{"exclude-from", "", POPT_ARG_STRING, nil, OPT_EXCLUDE_FROM},
 		//{"include-from", "", POPT_ARG_STRING, nil, OPT_INCLUDE_FROM},
 		//{"cvs-exclude", "C", POPT_ARG_NONE, &o.cvs_exclude, 0},
-		//{"whole-file", "W", POPT_ARG_VAL, &o.whole_file, 1},
-		//{"no-whole-file", "", POPT_ARG_VAL, &o.whole_file, 0},
-		//{"no-W", "", POPT_ARG_VAL, &o.whole_file, 0},
+		{"whole-file", "W", POPT_ARG_VAL, &o.whole_file, 1},
+		{"no-whole-file", "", POPT_ARG_VAL, &o.whole_file, 0},
+		{"no-W", "", POPT_ARG_VAL, &o.whole_file, 0},
 		{"checksum", "c", POPT_ARG_VAL, &o.always_checksum, 1},
 		{"no-checksum", "", POPT_ARG_VAL, &o.always_checksum, 0},
 		{"no-c", "", POPT_ARG_VAL, &o.always_checksum, 0},

--- a/internal/rsyncopts/serveroptions.go
+++ b/internal/rsyncopts/serveroptions.go
@@ -46,8 +46,9 @@ func (o *Options) ServerOptions() []string {
 	// if (copy_links)
 	// 	argstr[x++] = 'L';
 
-	// if (whole_file > 0)
-	// 	argstr[x++] = 'W';
+	if o.whole_file > 0 {
+		argstr += "W"
+	}
 	// /* We don't need to send --no-whole-file, because it's the
 	//  * default for remote transfers, and in any case old versions
 	//  * of rsync will not understand it. */

--- a/rsyncd/rsyncd.go
+++ b/rsyncd/rsyncd.go
@@ -444,6 +444,7 @@ func (s *Server) handleConnReceiver(module *Module, crd *rsyncwire.CountingReade
 			// TODO: PreserveHardlinks: opts.PreserveHardlinks,
 			IgnoreTimes:    opts.IgnoreTimes(),
 			AlwaysChecksum: opts.AlwaysChecksum(),
+			WholeFile:      opts.WholeFile(),
 
 			InfoGTE:  opts.InfoGTE,
 			DebugGTE: opts.DebugGTE,


### PR DESCRIPTION
## Summary
The gokrazy fork parses but never acts on `-W`. This PR plumbs it end-to-end so callers (`rsyncclient.New`, `rsynccmd.Command`) can ask for whole-file mode and have it actually take effect on the wire and in the receiver.

Three coordinated changes:

1. **Parser** — `internal/rsyncopts/rsyncopts.go`: uncomments the `--whole-file`/`-W`/`--no-whole-file`/`--no-W` entries in `gokrazyTable()` so the client side actually accepts these flags. Adds an `Options.WholeFile()` accessor.
2. **Wire (client → daemon)** — `internal/rsyncopts/serveroptions.go`: emits `W` in argstr when `whole_file > 0`, so the remote daemon learns the client is asking for whole-file mode.
3. **Receiver** — `internal/receiver/{generator,transfer}.go`: plumbs `WholeFile` through `TransferOpts` and consults it in `recvGenerator` to short-circuit to `requestFullFile()` instead of generating rolling checksums against an existing local file. Wires the field at both `internal/maincmd/clientmaincmd.go` and `rsyncd/rsyncd.go` construction sites.

## Why
Without this, even after enabling the parser, `-W` had no observable effect. A pull against an existing partial would still walk the slow delta-sync path because the receiver kept generating sums; pushes were also stuck on the slow path because the daemon never received `-W` and could not skip its own work.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` pass (full suite, including `internal/rsyncopts`, `rsyncclient`, `internal/maincmd`, integration tests)
- [x] Repro: before this PR, `rsynccmd.Command(\"rsync\", \"-W\", ...)` failed with `-W: unknown option`; after, parses and propagates to wire.