### PR TITLE
Add the ability to specify a net.DialContext to use for clients

### DIFF
--- a/internal/maincmd/clientserver.go
+++ b/internal/maincmd/clientserver.go
@@ -41,12 +41,19 @@ func socketClient(ctx context.Context, osenv *rsyncos.Env, opts *rsyncopts.Optio
 		dialer.Timeout = time.Duration(timeout) * time.Second
 		timeoutStr = fmt.Sprintf(" (timeout: %d seconds)", timeout)
 	}
-	osenv.Logf("Opening TCP connection to %s%s", host, timeoutStr)
-	conn, err := dialer.DialContext(ctx, "tcp", host)
+	dialFn := dialer.DialContext
+	if osenv.DialContext != nil {
+		dialFn = osenv.DialContext
+		osenv.Logf("Opening TCP connection to %s%s (via custom DialContext)", host, timeoutStr)
+	} else {
+		osenv.Logf("Opening TCP connection to %s%s", host, timeoutStr)
+	}
+	conn, err := dialFn(ctx, "tcp", host)
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Close()
+
 	if osenv.Restrict() {
 		if err := restrict.MaybeFileSystem(roDirs, rwDirs); err != nil {
 			return nil, err

--- a/internal/rsyncos/rsyncos.go
+++ b/internal/rsyncos/rsyncos.go
@@ -1,7 +1,9 @@
 package rsyncos
 
 import (
+	"context"
 	"io"
+	"net"
 
 	"github.com/gokrazy/rsync/internal/log"
 )
@@ -12,6 +14,8 @@ type Env struct {
 	Stderr io.Writer
 
 	DontRestrict bool
+
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 
 	logger log.Logger
 }

--- a/rsynccmd/rsynccmd.go
+++ b/rsynccmd/rsynccmd.go
@@ -21,6 +21,7 @@ package rsynccmd
 import (
 	"context"
 	"io"
+	"net"
 
 	"github.com/gokrazy/rsync/internal/maincmd"
 	"github.com/gokrazy/rsync/internal/rsyncos"
@@ -34,6 +35,8 @@ type Cmd struct {
 	Stdout       io.Writer
 	Stderr       io.Writer
 	DontRestrict bool
+
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
 // Command returns the [Cmd] struct to execute rsync with the given arguments.
@@ -58,6 +61,7 @@ func (c *Cmd) Run(ctx context.Context) (*Result, error) {
 		Stdout:       c.Stdout,
 		Stderr:       c.Stderr,
 		DontRestrict: c.DontRestrict,
+		DialContext:  c.DialContext,
 	}
 	stats, err := maincmd.Main(ctx, osenv, c.Args, nil)
 	if err != nil {


### PR DESCRIPTION
This has two obvious use cases, the first and perhaps the most obvious being that it allows people to use things like SOCKS5 proxies with their client connections, however the use case that i'm particularly interested in is that i'm wanting to wrap the connection in some custom timeout logic to try and prevent deadlocked client connections from harming my end application embedding this library

```
[23:06:26] ben@metropolis:~/go/src/github.com/benjojo/rsync$ make test
GOGC=off CGO_ENABLED=0 go test -fullpath ./...
?   	github.com/gokrazy/rsync	[no test files]
?   	github.com/gokrazy/rsync/cmd/gokr-rsync	[no test files]
?   	github.com/gokrazy/rsync/cmd/gokr-rsyncd	[no test files]
ok  	github.com/gokrazy/rsync/integration/errors	0.086s
ok  	github.com/gokrazy/rsync/integration/flist	6.747s
ok  	github.com/gokrazy/rsync/integration/fsfs	0.015s
ok  	github.com/gokrazy/rsync/integration/interop	0.233s
ok  	github.com/gokrazy/rsync/integration/ipacl	0.088s
ok  	github.com/gokrazy/rsync/integration/receiver	0.349s
ok  	github.com/gokrazy/rsync/integration/sender	0.054s
ok  	github.com/gokrazy/rsync/integration/sync	0.231s
?   	github.com/gokrazy/rsync/internal/anonssh	[no test files]
ok  	github.com/gokrazy/rsync/internal/log	0.004s [no tests to run]
ok  	github.com/gokrazy/rsync/internal/maincmd	0.005s
ok  	github.com/gokrazy/rsync/internal/progress	0.004s
?   	github.com/gokrazy/rsync/internal/receiver	[no test files]
?   	github.com/gokrazy/rsync/internal/restrict	[no test files]
ok  	github.com/gokrazy/rsync/internal/rsyncchecksum	0.019s
?   	github.com/gokrazy/rsync/internal/rsynccommon	[no test files]
ok  	github.com/gokrazy/rsync/internal/rsyncdconfig	0.008s
ok  	github.com/gokrazy/rsync/internal/rsyncopts	0.014s
?   	github.com/gokrazy/rsync/internal/rsyncos	[no test files]
?   	github.com/gokrazy/rsync/internal/rsyncostest	[no test files]
?   	github.com/gokrazy/rsync/internal/rsyncstats	[no test files]
?   	github.com/gokrazy/rsync/internal/rsynctest	[no test files]
?   	github.com/gokrazy/rsync/internal/rsyncwire	[no test files]
ok  	github.com/gokrazy/rsync/internal/sender	0.004s
?   	github.com/gokrazy/rsync/internal/testlogger	[no test files]
?   	github.com/gokrazy/rsync/internal/version	[no test files]
ok  	github.com/gokrazy/rsync/rsyncclient	0.016s
?   	github.com/gokrazy/rsync/rsynccmd	[no test files]
ok  	github.com/gokrazy/rsync/rsyncd	0.006s [no tests to run]

[23:06:38] ben@metropolis:~/go/src/github.com/benjojo/rsync$ make 
CGO_ENABLED=0 go install github.com/gokrazy/rsync/cmd/...
```