### PR TITLE
rsyncclient: support --delete and include/exclude filters when sending

### DIFF
--- a/internal/maincmd/clientmaincmd.go
+++ b/internal/maincmd/clientmaincmd.go
@@ -325,7 +325,32 @@ func ClientRun(osenv *rsyncos.Env, opts *rsyncopts.Options, conn io.ReadWriter, 
 			}
 		}
 
-		stats, err := st.Do(crd, cwr, FileSystemRoot, paths, nil)
+		// In delete mode the receiving server reads our filter list (so it knows
+		// which extraneous files are protected from deletion), exactly mirroring
+		// rsyncd's handleConnReceiver, which reads it iff DeleteMode. Sending it
+		// unconditionally would desync a non-delete receiver, which never reads it.
+		if opts.DeleteMode() {
+			for _, rule := range opts.FilterRules() {
+				if err := c.WriteInt32(int32(len(rule))); err != nil {
+					return nil, err
+				}
+				if err := c.WriteString(rule); err != nil {
+					return nil, err
+				}
+			}
+			const exclusionListEnd = 0
+			if err := c.WriteInt32(exclusionListEnd); err != nil {
+				return nil, err
+			}
+		}
+
+		// As the sender we also build the file list ourselves, so apply the
+		// include/exclude filters locally (skip excluded files entirely).
+		excl, err := sender.ParseFilterRules(opts.FilterRules())
+		if err != nil {
+			return nil, err
+		}
+		stats, err := st.Do(crd, cwr, FileSystemRoot, paths, excl)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/rsyncopts/serveroptions.go
+++ b/internal/rsyncopts/serveroptions.go
@@ -146,10 +146,13 @@ func (o *Options) ServerOptions() []string {
 	// 	args[ac++] = arg;
 	// }
 
-	// if (delete_excluded)
-	// 	args[ac++] = "--delete-excluded";
-	// else if (delete_mode)
-	// 	args[ac++] = "--delete";
+	// Tell the server (when it is the receiver) to delete extraneous files.
+	// Only a receiving server acts on this; a sending server ignores it.
+	if o.delete_excluded != 0 {
+		sargv = append(sargv, "--delete-excluded")
+	} else if o.delete_mode != 0 {
+		sargv = append(sargv, "--delete")
+	}
 
 	// if (size_only)
 	// 	args[ac++] = "--size-only";

--- a/internal/sender/exclude.go
+++ b/internal/sender/exclude.go
@@ -26,11 +26,30 @@ func (l *filterRuleList) addRule(fr *filterRule) {
 	l.Filters = append(l.Filters, fr)
 }
 
-// exclude.c:check_filter
+// ParseFilterRules builds a filter rule list from textual rules (as produced by
+// Options.FilterRules(), e.g. "- *.log" / "+ keep.txt"). It is used by the
+// client when it is the sender, so that excluded files are not even put into the
+// file list (rsync/exclude.c:parse_filter_str + add_rule).
+func ParseFilterRules(rules []string) (*filterRuleList, error) {
+	var l filterRuleList
+	for _, rule := range rules {
+		fr, err := parseFilter(rule)
+		if err != nil {
+			return nil, err
+		}
+		l.addRule(fr)
+	}
+	return &l, nil
+}
+
+// matches reports whether name should be excluded. Rules are evaluated in order
+// and the first one that matches decides: an exclude rule excludes (true), an
+// include rule protects the file from exclusion (false). This mirrors
+// rsync/exclude.c:check_filter.
 func (l *filterRuleList) matches(name string) bool {
 	for _, fr := range l.Filters {
 		if fr.matches(name) {
-			return true
+			return fr.flag&filtruleInclude == 0
 		}
 	}
 	return false
@@ -75,14 +94,101 @@ type filterRule struct {
 
 // exclude.c:rule_matches
 func (fr *filterRule) matches(name string) bool {
-	if fr.flag&filtruleWild != 0 {
-		panic("wildcard filter rules not yet implemented")
-	}
-	if !strings.ContainsRune(fr.pattern, '/') &&
-		fr.flag&filtruleWild == 0 {
+	pattern := fr.pattern
+	// A pattern with no slash matches against the basename only; a pattern with
+	// a slash is anchored and matches against the whole (relative) path.
+	if !strings.ContainsRune(pattern, '/') {
 		name = filepath.Base(name)
 	}
-	return fr.pattern == name
+	if fr.flag&filtruleWild != 0 {
+		return wildmatch(pattern, name)
+	}
+	return pattern == name
+}
+
+// wildmatch implements the subset of rsync's lib/wildmatch.c that rsync filter
+// patterns use: '*' matches any run of characters except '/', '**' matches across
+// '/' too, '?' matches any single character except '/', and '[...]' is a
+// character class (with '!'/'^' negation and 'a-z' ranges).
+func wildmatch(pattern, text string) bool {
+	return dowild([]byte(pattern), []byte(text))
+}
+
+func dowild(p, t []byte) bool {
+	ti := 0
+	for pi := 0; pi < len(p); pi++ {
+		pc := p[pi]
+		if ti >= len(t) && pc != '*' {
+			return false
+		}
+		switch pc {
+		case '?':
+			if t[ti] == '/' {
+				return false
+			}
+			ti++
+		case '*':
+			doubleStar := pi+1 < len(p) && p[pi+1] == '*'
+			for pi+1 < len(p) && p[pi+1] == '*' {
+				pi++
+			}
+			if pi == len(p)-1 {
+				// Trailing star: '**' matches the rest unconditionally, a single
+				// '*' matches the rest only if it contains no '/'.
+				return doubleStar || !bytesContainsSlash(t[ti:])
+			}
+			for ; ti <= len(t); ti++ {
+				if dowild(p[pi+1:], t[ti:]) {
+					return true
+				}
+				if ti < len(t) && t[ti] == '/' && !doubleStar {
+					return false
+				}
+			}
+			return false
+		case '[':
+			pi++
+			negate := pi < len(p) && (p[pi] == '!' || p[pi] == '^')
+			if negate {
+				pi++
+			}
+			matched := false
+			first := true
+			for pi < len(p) && (p[pi] != ']' || first) {
+				if pi+2 < len(p) && p[pi+1] == '-' && p[pi+2] != ']' {
+					if t[ti] >= p[pi] && t[ti] <= p[pi+2] {
+						matched = true
+					}
+					pi += 3
+				} else {
+					if t[ti] == p[pi] {
+						matched = true
+					}
+					pi++
+				}
+				first = false
+			}
+			if matched == negate {
+				return false
+			}
+			ti++
+		default:
+			if t[ti] != pc {
+				return false
+			}
+			ti++
+		}
+	}
+	return ti == len(t)
+}
+
+func bytesContainsSlash(b []byte) bool {
+	for _, c := range b {
+		if c == '/' {
+			return true
+		}
+	}
+	return false
 }
 
 // exclude.c:parse_filter_str / exclude.c:parse_rule_tok

--- a/internal/sender/exclude_test.go
+++ b/internal/sender/exclude_test.go
@@ -1,0 +1,57 @@
+package sender
+
+import "testing"
+
+func TestWildmatch(t *testing.T) {
+	for _, tt := range []struct {
+		pattern string
+		text    string
+		want    bool
+	}{
+		{"*.log", "foo.log", true},
+		{"*.log", "foo.txt", false},
+		{"*.log", "a.b.log", true},
+		{"?.log", "a.log", true},
+		{"?.log", "ab.log", false},
+		{"foo", "foo", true},
+		{"f*o", "fooo", true},
+		{"f*o", "fox", false},
+		// '*' must not cross '/', '**' may.
+		{"a/*", "a/b", true},
+		{"a/*", "a/b/c", false},
+		{"a/**", "a/b/c", true},
+		{"*", "a/b", false},
+		{"**", "a/b", true},
+		// character classes
+		{"[ab].txt", "a.txt", true},
+		{"[ab].txt", "c.txt", false},
+		{"[a-c].txt", "b.txt", true},
+		{"[!a-c].txt", "d.txt", true},
+		{"[!a-c].txt", "b.txt", false},
+	} {
+		if got := wildmatch(tt.pattern, tt.text); got != tt.want {
+			t.Errorf("wildmatch(%q, %q) = %v, want %v", tt.pattern, tt.text, got, tt.want)
+		}
+	}
+}
+
+func TestFilterRuleListMatches(t *testing.T) {
+	// Exclude *.log, but an earlier include for keep.log wins (first match decides).
+	l, err := ParseFilterRules([]string{"+ keep.log", "- *.log"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !l.matches("foo.log") {
+		t.Errorf("foo.log should be excluded")
+	}
+	if l.matches("keep.log") {
+		t.Errorf("keep.log should be protected by the include rule")
+	}
+	if l.matches("foo.txt") {
+		t.Errorf("foo.txt should not be excluded")
+	}
+	// A pattern with no slash matches by basename.
+	if !l.matches("deep/nested/foo.log") {
+		t.Errorf("basename match should exclude deep/nested/foo.log")
+	}
+}

--- a/internal/sender/flist.go
+++ b/internal/sender/flist.go
@@ -146,7 +146,12 @@ func (s *scopedWalker) walkFn(path string, d fs.DirEntry, err error) error {
 	// st.logger.Printf("flags for %q: %v", name, flags)
 
 	if s.excl.matches(name) {
-		return filepath.SkipDir
+		// Skip the whole subtree for a directory, but for a regular file only
+		// skip that one file — returning SkipDir there would drop its siblings.
+		if info.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
 	}
 
 	s.fileList.Files = append(s.fileList.Files, file{

--- a/rsyncclient/delete_exclude_test.go
+++ b/rsyncclient/delete_exclude_test.go
@@ -1,0 +1,83 @@
+package rsyncclient_test
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/gokrazy/rsync/internal/rsynctest"
+	"github.com/gokrazy/rsync/internal/testlogger"
+	"github.com/gokrazy/rsync/rsyncclient"
+)
+
+// TestClientSenderDeleteExclude exercises the client as the sender (push) with
+// --delete and a wildcard --exclude against a real rsync --server receiver.
+func TestClientSenderDeleteExclude(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	dest := filepath.Join(tmp, "dest")
+	for _, d := range []string{src, dest} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Source: one file to keep, one to exclude by wildcard.
+	if err := os.WriteFile(filepath.Join(src, "keep.txt"), []byte("keep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "drop.log"), []byte("drop"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Dest: a pre-existing extraneous file that --delete must prune.
+	if err := os.WriteFile(filepath.Join(dest, "stale.txt"), []byte("stale"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := rsyncclient.New(
+		[]string{"-a", "--delete", "--exclude=*.log"},
+		rsyncclient.WithSender(),
+		rsyncclient.WithStderr(testlogger.New(t)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rsync := exec.Command(rsynctest.AnyRsync(t), client.ServerCommandOptions(dest)...)
+	wc, err := rsync.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc, err := rsync.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsync.Stderr = testlogger.New(t)
+	if err := rsync.Start(); err != nil {
+		t.Fatal(err)
+	}
+	conn := &struct {
+		io.Reader
+		io.Writer
+	}{Reader: rc, Writer: wc}
+	if _, err := client.Run(t.Context(), conn, []string{src + "/"}); err != nil {
+		t.Fatal(err)
+	}
+	wc.Close()
+	if err := rsync.Wait(); err != nil {
+		t.Fatalf("rsync server: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dest, "keep.txt")); err != nil {
+		t.Errorf("keep.txt should have been synced: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "drop.log")); !os.IsNotExist(err) {
+		t.Errorf("drop.log should have been excluded, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "stale.txt")); !os.IsNotExist(err) {
+		t.Errorf("stale.txt should have been deleted by --delete, stat err=%v", err)
+	}
+}


### PR DESCRIPTION
When the pure-Go client acts as the **sender** (push), it parsed `--delete` and
`--exclude`/`--include`/`--filter` but silently ignored them:

- `server_options()` never emitted `--delete`/`--delete-excluded`, so the
  receiving server was never told to prune extraneous files;
- the sender passed a `nil` filter list to `Transfer.Do()`, so excluded files
  were still walked into the file list;
- `filterRule.matches()` panicked on any wildcard pattern (e.g. `*.log`);
- a matched **regular file** returned `filepath.SkipDir`, dropping its siblings.

(The receiver/pull path already worked: `rsyncd` deletes when `DeleteMode`, and a
client-receiver already sends its filter list to the remote sender.)

This wires the sender path to match what `rsyncd` already does as a server and what
tridge/openrsync expect on the wire:

- emit `--delete-excluded` / `--delete` in `ServerOptions()`;
- parse `opts.FilterRules()` into a filter list and apply it locally
  (`ParseFilterRules`), skipping only the matched file or subtree;
- implement `wildmatch` (`*`, `**`, `?`, `[..]`) for filter patterns;
- send the filter list to the receiver **iff** delete mode is set, mirroring
  `handleConnReceiver`, which reads it iff `DeleteMode`. Sending it unconditionally
  desyncs a non-delete receiver, which never reads it (I hit that hang; hence the
  condition).

## Tests

- `internal/sender`: `wildmatch` + filter-precedence unit tests.
- `rsyncclient`: `TestClientSenderDeleteExclude` pushes to a real `rsync --server`
  with `--delete` and a wildcard `--exclude=*.log`, asserting the excluded file is
  not sent and an extraneous dest file is pruned.

Full `go test ./...` passes (interop included, against rsync 3.4.3).